### PR TITLE
fix(skill-validator): pass github-token to validation step

### DIFF
--- a/skill_validator/action.yml
+++ b/skill_validator/action.yml
@@ -107,6 +107,7 @@ runs:
         INPUT_CONFIG: ${{ inputs.config }}
         INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
         INPUT_SKILLS_DIR: ${{ inputs.skills-dir }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         SCOPE_ARGS="--scope ${INPUT_SCOPE}"
         if [ -n "${INPUT_BASE}" ]; then


### PR DESCRIPTION
## Summary

- The github-token input was only forwarded as GH_TOKEN to the Post PR comment step, but not to the Run validation step where the skill-validator binary actually needs it
- The binary checks GITHUB_TOKEN / GH_TOKEN env vars to perform GitHub-dependent lints (src/github.rs), so without the token it skips those lints with a warning
- Adds GITHUB_TOKEN to the validation step env block

## Test plan

- [ ] Verify a PR in agent-skills-sandbox no longer shows the No GitHub token found warning when github-token is provided
- [ ] Confirm GitHub-dependent lints now execute