### PR TITLE
feat(skill-validator): add --files flag for pre-commit integration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: validate-skills
   name: Validate Agent Skills
   entry: skill-validator
-  language: system
+  language: rust
   files: ^skills/
   pass_filenames: true
   args: ["--files"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,6 @@
   entry: skill-validator
   language: system
   files: ^skills/
-  pass_filenames: false
+  pass_filenames: true
+  args: ["--files"]
   description: Validate skill folder structure, frontmatter, and content conventions.

--- a/skill_validator/Cargo.lock
+++ b/skill_validator/Cargo.lock
@@ -1285,7 +1285,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skill-validator"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/skill_validator/Cargo.toml
+++ b/skill_validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skill-validator"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.77"
 description = "A Trustfall-powered linting tool for validating Agent Skills repositories"

--- a/skill_validator/src/git.rs
+++ b/skill_validator/src/git.rs
@@ -19,6 +19,28 @@ pub fn resolve_base_ref(explicit: Option<&str>) -> String {
     "origin/main".to_string()
 }
 
+/// Derive the set of skill directory paths from an explicit list of file paths.
+///
+/// Used in pre-commit mode where the hook runner passes the staged file paths
+/// directly. Each path is mapped to its enclosing skill directory at depth 2
+/// under `skills_prefix` (i.e. `<group>/<skill-name>/`). Paths outside
+/// `skills_prefix` or at insufficient depth are ignored.
+pub fn skill_dirs_from_files(files: &[std::path::PathBuf], skills_prefix: &str) -> HashSet<String> {
+    let mut dirs = HashSet::new();
+    for file in files {
+        let file_str = file.to_string_lossy();
+        let line = file_str.trim();
+        if let Some(rel) = strip_prefix_normalized(line, skills_prefix) {
+            let components: Vec<&str> = rel.split('/').collect();
+            if components.len() >= 2 {
+                let skill_dir = format!("{}/{}/{}", skills_prefix, components[0], components[1]);
+                dirs.insert(skill_dir);
+            }
+        }
+    }
+    dirs
+}
+
 /// Return the set of skill directory paths (relative to `repo_root`) that have
 /// changed files compared to `base_ref`.
 ///
@@ -119,5 +141,34 @@ mod tests {
     #[test]
     fn strip_prefix_exact_match_returns_none() {
         assert_eq!(strip_prefix_normalized("skills", "skills"), None);
+    }
+
+    #[test]
+    fn skill_dirs_from_files_basic() {
+        let files: Vec<std::path::PathBuf> = vec![
+            "skills/es/query/SKILL.md".into(),
+            "skills/es/query/scripts/helper.js".into(),
+            "skills/other/group/skill/file.txt".into(), // depth 3+ → maps to skills/other/group
+            "unrelated/file.txt".into(),
+        ];
+        let dirs = skill_dirs_from_files(&files, "skills");
+        assert!(dirs.contains("skills/es/query"), "should include es/query");
+        assert!(dirs.contains("skills/other/group"), "should include other/group");
+        assert!(!dirs.contains("skills/other/group/skill"), "should not go deeper than depth 2");
+        assert!(!dirs.iter().any(|d| d.contains("unrelated")), "unrelated files should be excluded");
+    }
+
+    #[test]
+    fn skill_dirs_from_files_empty() {
+        let files: Vec<std::path::PathBuf> = vec![];
+        let dirs = skill_dirs_from_files(&files, "skills");
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn skill_dirs_from_files_no_matches() {
+        let files: Vec<std::path::PathBuf> = vec!["README.md".into(), "other/file.txt".into()];
+        let dirs = skill_dirs_from_files(&files, "skills");
+        assert!(dirs.is_empty());
     }
 }

--- a/skill_validator/src/main.rs
+++ b/skill_validator/src/main.rs
@@ -105,6 +105,12 @@ struct LintArgs {
     #[arg(long, value_name = "PATH")]
     comment: Option<PathBuf>,
 
+    /// Validate only the skills that contain these files (pre-commit mode).
+    /// When set, scope/base options are ignored. Pre-commit passes staged
+    /// filenames here via: `args: ["--files"]` + `pass_filenames: true`.
+    #[arg(long = "files", num_args = 1.., value_name = "FILE")]
+    files: Vec<PathBuf>,
+
     /// Automatically fix auto-fixable issues (reserved for future use)
     #[arg(long)]
     fix: bool,
@@ -237,7 +243,23 @@ fn run_lint_command(args: LintArgs) -> ExitCode {
 
     let skills_dir = args.skills_dir.unwrap_or_else(|| cfg.skills_dir.clone());
 
-    let scope_filter = if args.scope == Scope::Changed {
+    let scope_filter = if !args.files.is_empty() {
+        // Pre-commit mode: derive skill dirs from the explicitly provided file list.
+        let skills_prefix = skills_dir.to_string_lossy();
+        let skills_prefix = skills_prefix.trim_end_matches('/');
+        let dirs = git::skill_dirs_from_files(&args.files, skills_prefix);
+        if args.verbose {
+            eprintln!("Pre-commit mode: {} skill(s) in scope", dirs.len());
+            for d in &dirs {
+                eprintln!("  {d}");
+            }
+        }
+        if dirs.is_empty() {
+            eprintln!("No skills found in the provided file list — nothing to validate.");
+            return ExitCode::SUCCESS;
+        }
+        Some(dirs)
+    } else if args.scope == Scope::Changed {
         let repo_root = match std::env::current_dir() {
             Ok(d) => d,
             Err(e) => {


### PR DESCRIPTION
## Summary

Adds a `--files <FILE>...` CLI flag so `skill-validator` can be driven directly by pre-commit, which passes staged filenames as positional arguments after the configured `args`.

## Changes

### `skill_validator/src/git.rs`
- New `skill_dirs_from_files()` helper: derives a skill-dir scope filter from an explicit file list using the same depth-2 mapping logic as `changed_skill_dirs`
- 3 new unit tests covering basic, empty, and no-match cases

### `skill_validator/src/main.rs`
- New `--files <FILE>...` flag (`num_args=1..`) in `LintArgs`
- When `--files` is non-empty, it takes precedence over `--scope`/`--base` and skips git entirely — only the skills containing the listed files are validated

### `.pre-commit-hooks.yaml`
- `pass_filenames: true` + `args: ["--files"]`
- pre-commit will now call: `skill-validator --files <staged files...>`

### `skill_validator/Cargo.toml`
- Version bump `0.6.1` → `0.6.2`

## How it works

```yaml
# .pre-commit-hooks.yaml (after)
- id: validate-skills
  entry: skill-validator
  pass_filenames: true
  args: ["--files"]
```

pre-commit stages e.g. `skills/es/query/SKILL.md` and `skills/es/reindex/scripts/helper.js`, then calls:
```
skill-validator --files skills/es/query/SKILL.md skills/es/reindex/scripts/helper.js
```
The validator maps those paths to skill dirs `skills/es/query` and `skills/es/reindex` and validates only those two skills — no git diff required.