### PR TITLE
docs: document agent label convention and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ jobs:
 
 **Requires**: `LITELLM_API_KEY` secret in the calling repo.
 
-## Agent label convention
+## `auto-pr` label convention
 
-Workflows that auto-fix issues on demand use the label prefix `agent: <task>`.
+Adding an `auto-pr` label (or `auto-pr: <context>`) to an issue signals that an AI agent should process it and open a fix PR.
 
-Adding an `agent: <task>` label to an issue signals that an AI agent should process it. Each repo registers which label it handles:
+Workflows check `startsWith('auto-pr')`, so both `auto-pr` and `auto-pr: kibana type check` trigger the same workflow. The suffix is optional context for humans.
 
 | Label | Repo | What it does |
 |---|---|---|
-| `agent: kibana type check` | `elastic/elasticsearch-specification` | Reads the issue, locates the relevant spec types, and opens a fix PR |
+| `auto-pr: kibana type check` | `elastic/elasticsearch-specification` | Reads the issue, locates the relevant spec types, and opens a fix PR |
 
-To add a new agent: create a workflow in your repo that triggers on `issues: labeled`, checks for your label, and implements the fix.
+To add a new agent in your repo: create a workflow that triggers on `issues: labeled` and checks `startsWith(github.event.label.name, 'auto-pr')`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,44 @@
 
 Contains shared reusable GitHub Actions workflows of the clients team.
 
-.
+## Workflows
 
-.
+### AI Backport Resolver (`ai-backport-resolver.yml`)
 
-.
+Reusable `workflow_call` workflow. When the backport bot posts a failure comment on a PR, resolves cherry-pick conflicts using Claude (via LiteLLM) and opens a backport PR.
+
+**Usage** — add to your repo as a thin caller:
+
+```yaml
+# .github/workflows/resolve-conflicts.yml
+name: AI Backport Resolver
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  resolve:
+    uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main
+    with:
+      comment_body: ${{ github.event.comment.body }}
+      comment_user: ${{ github.event.comment.user.login }}
+      pr_number: ${{ github.event.issue.number }}
+    secrets:
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+```
+
+**Requires**: `LITELLM_API_KEY` secret in the calling repo.
+
+## Agent label convention
+
+Workflows that auto-fix issues on demand use the label prefix `agent: <task>`.
+
+Adding an `agent: <task>` label to an issue signals that an AI agent should process it. Each repo registers which label it handles:
+
+| Label | Repo | What it does |
+|---|---|---|
+| `agent: kibana type check` | `elastic/elasticsearch-specification` | Reads the issue, locates the relevant spec types, and opens a fix PR |
+
+To add a new agent: create a workflow in your repo that triggers on `issues: labeled`, checks for your label, and implements the fix.
 
 ## License
 


### PR DESCRIPTION
Documents the `agent: <task>` label convention used across client repos for AI-driven issue fixing.

Also documents the `ai-backport-resolver.yml` usage.