### PR TITLE
feat: add auto-pr and ai-backport-resolver reusable workflows

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,210 @@
+name: Auto PR
+# Reusable workflow — triggered by an "auto-pr" label on an issue.
+# Reads the issue, searches the calling repo for relevant files, calls Claude
+# to produce a fix, and opens a PR.
+#
+# The calling repo should provide .github/auto-pr-context.md with:
+#   - A description of the codebase and conventions
+#   - Where relevant files live (e.g. "type definitions are in specification/")
+#   - What kinds of fixes are expected
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: "Issue number to fix"
+        required: true
+        type: number
+      search_directory:
+        description: "Directory to search for relevant files (default: repo root)"
+        required: false
+        type: string
+        default: "."
+    secrets:
+      LITELLM_API_KEY:
+        description: "API key for elastic.litellm-prod.ai"
+        required: true
+
+jobs:
+  create-pr:
+    name: Auto PR from issue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Read issue and find relevant files
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          SEARCH_DIR: ${{ inputs.search_directory }}
+        run: |
+          set -euo pipefail
+
+          # Read issue
+          gh issue view "$ISSUE_NUMBER" --json number,title,body,labels \
+            > /tmp/issue.json
+
+          ISSUE_TITLE=$(jq -r '.title' /tmp/issue.json)
+          ISSUE_BODY=$(jq -r '.body' /tmp/issue.json)
+
+          echo "Issue: #${ISSUE_NUMBER} - ${ISSUE_TITLE}"
+
+          # Read repo-specific context if present
+          if [ -f .github/auto-pr-context.md ]; then
+            CONTEXT=$(cat .github/auto-pr-context.md)
+          else
+            CONTEXT="No additional context provided."
+          fi
+
+          # Extract potential identifiers (type names, symbols) from the issue body
+          # Look for PascalCase words and quoted identifiers as search terms
+          TERMS=$(echo "$ISSUE_BODY" | \
+            grep -oE "'[A-Za-z_][A-Za-z0-9_.]+'" | tr -d "'" | sort -u | head -20 || true)
+          if [ -z "$TERMS" ]; then
+            TERMS=$(echo "$ISSUE_BODY" | \
+              grep -oE '\b[A-Z][a-zA-Z0-9]{3,}\b' | sort -u | head -20 || true)
+          fi
+
+          echo "Search terms: $TERMS"
+
+          # Find files containing those terms (limit to 10 files, 500 lines each)
+          FILE_CONTENTS=""
+          if [ -n "$TERMS" ]; then
+            while IFS= read -r term; do
+              while IFS= read -r filepath; do
+                if [ -z "$filepath" ]; then continue; fi
+                if echo "$FILE_CONTENTS" | grep -q "^=== $filepath"; then continue; fi
+                FILE_CONTENTS="${FILE_CONTENTS}
+          === ${filepath} ===
+          $(head -500 "$filepath")
+          "
+                # Cap total context size
+                if [ "${#FILE_CONTENTS}" -gt 80000 ]; then break 2; fi
+              done < <(grep -rl "$term" "$SEARCH_DIR" \
+                --include="*.ts" --include="*.yml" --include="*.yaml" --include="*.json" \
+                2>/dev/null | head -5 || true)
+            done <<< "$TERMS"
+          fi
+
+          # Write context files for next step
+          printf '%s' "$ISSUE_TITLE" > /tmp/issue-title.txt
+          printf '%s' "$ISSUE_BODY" > /tmp/issue-body.txt
+          printf '%s' "$CONTEXT" > /tmp/repo-context.txt
+          printf '%s' "$FILE_CONTENTS" > /tmp/relevant-files.txt
+
+      - name: Call Claude and apply fix
+        env:
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_TITLE=$(cat /tmp/issue-title.txt)
+          ISSUE_BODY=$(cat /tmp/issue-body.txt)
+          REPO_CONTEXT=$(cat /tmp/repo-context.txt)
+          RELEVANT_FILES=$(cat /tmp/relevant-files.txt)
+
+          BRANCH="auto-pr/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | \
+            tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-40)"
+
+          printf '%s\n' \
+            "You are an AI assistant that fixes GitHub issues by editing code files." \
+            "" \
+            "REPOSITORY CONTEXT:" \
+            "$REPO_CONTEXT" \
+            "" \
+            "ISSUE #${ISSUE_NUMBER}: ${ISSUE_TITLE}" \
+            "$ISSUE_BODY" \
+            "" \
+            "RELEVANT FILES FOUND IN THE REPOSITORY:" \
+            "$RELEVANT_FILES" \
+            "" \
+            "INSTRUCTIONS:" \
+            "1. Analyze the issue and determine the minimal code changes needed." \
+            "2. Respond with ONLY a valid JSON object (no markdown fences) in this exact format:" \
+            '{' \
+            '  "branch": "'"$BRANCH"'",' \
+            '  "commit_message": "fix: <short description>",' \
+            '  "pr_title": "<PR title>",' \
+            '  "pr_body": "<PR body with closes #'"$ISSUE_NUMBER"' and explanation>",' \
+            '  "changes": [' \
+            '    { "file": "path/to/file.ts", "content": "<full file content after fix>" }' \
+            '  ]' \
+            '}' \
+            "3. Only include files that actually need changes." \
+            "4. Always include the full file content (not just the changed lines)." \
+            "5. Do not invent files — only modify files shown above." \
+            > /tmp/prompt.txt
+
+          RESPONSE=$(curl -sf \
+            -H "Authorization: Bearer ${LITELLM_API_KEY}" \
+            -H "Content-Type: application/json" \
+            "https://elastic.litellm-prod.ai/v1/chat/completions" \
+            -d "$(jq -n \
+              --rawfile prompt /tmp/prompt.txt \
+              '{
+                model: "llm-gateway/claude-sonnet-4-6",
+                max_tokens: 16384,
+                messages: [{role: "user", content: $prompt}]
+              }')")
+
+          CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+
+          if [ -z "$CONTENT" ]; then
+            echo "ERROR: Empty response from Claude."
+            exit 1
+          fi
+
+          # Parse the JSON response
+          echo "$CONTENT" > /tmp/claude-response.json
+
+          BRANCH=$(jq -r '.branch' /tmp/claude-response.json)
+          COMMIT_MSG=$(jq -r '.commit_message' /tmp/claude-response.json)
+          PR_TITLE=$(jq -r '.pr_title' /tmp/claude-response.json)
+          PR_BODY=$(jq -r '.pr_body' /tmp/claude-response.json)
+          NUM_CHANGES=$(jq '.changes | length' /tmp/claude-response.json)
+
+          if [ "$NUM_CHANGES" -eq 0 ]; then
+            echo "Claude proposed no file changes. Nothing to do."
+            gh issue comment "$ISSUE_NUMBER" \
+              --body "**Auto PR**: Claude analyzed the issue but determined no code changes are needed."
+            exit 0
+          fi
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+
+          # Apply file changes
+          jq -c '.changes[]' /tmp/claude-response.json | while IFS= read -r change; do
+            FILE=$(echo "$change" | jq -r '.file')
+            CONTENT=$(echo "$change" | jq -r '.content')
+            mkdir -p "$(dirname "$FILE")"
+            printf '%s' "$CONTENT" > "$FILE"
+            git add "$FILE"
+            echo "Applied: $FILE"
+          done
+
+          git commit -m "$COMMIT_MSG"
+          git push --set-upstream origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --label "auto-pr")
+
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "**Auto PR** opened a fix: ${PR_URL}"
+
+          echo "PR created: $PR_URL"

--- a/README.md
+++ b/README.md
@@ -2,15 +2,87 @@
 
 # Elastic Clients Team Automations
 
-Contains shared reusable GitHub Actions workflows of the clients team.
+Shared reusable GitHub Actions workflows for Elastic client repositories.
+
+---
 
 ## Workflows
 
-### AI Backport Resolver (`ai-backport-resolver.yml`)
+### 1. `auto-pr.yml` — AI-driven issue fix
 
-Reusable `workflow_call` workflow. When the backport bot posts a failure comment on a PR, resolves cherry-pick conflicts using Claude (via LiteLLM) and opens a backport PR.
+Reads a GitHub issue, finds relevant files in your repo, calls Claude (via LiteLLM) to produce a fix, and opens a PR. Triggered by adding an `auto-pr` label (or any label starting with `auto-pr:`) to an issue.
 
-**Usage** — add to your repo as a thin caller:
+#### Setup
+
+**Step 1** — Add a thin caller workflow to your repo:
+
+```yaml
+# .github/workflows/auto-pr.yml
+name: Auto PR
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  auto-pr:
+    if: startsWith(github.event.label.name, 'auto-pr')
+    uses: elastic/clients-team-automations/.github/workflows/auto-pr.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      search_directory: src   # optional — directory to search for relevant files
+    secrets:
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+```
+
+**Step 2** — Add a context file at `.github/auto-pr-context.md` in your repo:
+
+```markdown
+# Auto PR context — my-repo
+
+Brief description of what this repo contains and what kinds of issues are expected.
+
+## File layout
+- `src/` — main source files
+- `types/` — type definitions
+
+## Fix conventions
+- Describe what kind of changes Claude should make
+- e.g. "Only modify files under `src/types/`. Do not touch generated files."
+
+## Search hints
+- Mention what identifiers or patterns in the issue body map to which directories
+```
+
+**Step 3** — Add `LITELLM_API_KEY` as a repository secret (Settings → Secrets → Actions).
+
+**Step 4** — Create the `auto-pr` label in your repo (Settings → Labels), or use `auto-pr: <context>` for a more descriptive variant.
+
+#### How it works
+
+1. An issue is labeled with `auto-pr` (or `auto-pr: <description>`)
+2. The workflow reads the issue body and `.github/auto-pr-context.md`
+3. It extracts identifiers (type names, symbols) from the issue and searches `search_directory` for relevant files
+4. Claude receives the issue + file contents and returns a JSON patch with the file changes
+5. The changes are applied, committed, and a PR is opened — with a comment posted on the original issue
+
+#### Tips for a good context file
+
+The quality of the fix depends heavily on `.github/auto-pr-context.md`. Include:
+- What the repo does and what its conventions are
+- Which directory to look in for fixes
+- Common fix patterns with examples
+
+See [elasticsearch-specification's context file](https://github.com/elastic/elasticsearch-specification/blob/main/.github/auto-pr-context.md) as a reference.
+
+---
+
+### 2. `ai-backport-resolver.yml` — AI backport conflict resolver
+
+When the backport bot posts a failure comment on a PR, resolves cherry-pick conflicts using Claude and opens a backport PR automatically.
+
+#### Setup
+
+**Step 1** — Add a thin caller workflow to your repo:
 
 ```yaml
 # .github/workflows/resolve-conflicts.yml
@@ -18,6 +90,7 @@ name: AI Backport Resolver
 on:
   issue_comment:
     types: [created]
+
 jobs:
   resolve:
     uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main
@@ -29,19 +102,27 @@ jobs:
       LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
 ```
 
-**Requires**: `LITELLM_API_KEY` secret in the calling repo.
+**Step 2** — Add `LITELLM_API_KEY` as a repository secret.
+
+#### How it works
+
+1. The backport bot posts a failure comment starting with `"The backport to..."` on a merged PR
+2. The workflow parses the comment to extract the target branch and commit SHA
+3. It attempts the cherry-pick — if no conflicts, a backport PR is created directly
+4. If there are conflicts, Claude resolves them file by file
+5. A backport PR is opened and a comment is posted on the original PR
+
+---
 
 ## `auto-pr` label convention
 
-Adding an `auto-pr` label (or `auto-pr: <context>`) to an issue signals that an AI agent should process it and open a fix PR.
-
-Workflows check `startsWith('auto-pr')`, so both `auto-pr` and `auto-pr: kibana type check` trigger the same workflow. The suffix is optional context for humans.
+The `auto-pr` prefix is a shared convention across Elastic client repos. Adding an `auto-pr` label to an issue signals that an AI agent should process it and open a fix PR. Workflows check `startsWith(github.event.label.name, 'auto-pr')` so both `auto-pr` and `auto-pr: <context>` trigger — the suffix is optional human-readable context.
 
 | Label | Repo | What it does |
 |---|---|---|
-| `auto-pr: kibana type check` | `elastic/elasticsearch-specification` | Reads the issue, locates the relevant spec types, and opens a fix PR |
+| `auto-pr: kibana type check` | `elastic/elasticsearch-specification` | Fixes spec type errors found by the Kibana type check pipeline |
 
-To add a new agent in your repo: create a workflow that triggers on `issues: labeled` and checks `startsWith(github.event.label.name, 'auto-pr')`.
+To register your repo's agent, add a row to the table above in a PR to this README.
 
 ## License
 


### PR DESCRIPTION
Adds two reusable `workflow_call` workflows:

### `auto-pr.yml`
Issue-driven AI fix workflow. When called with an `issue_number`, it:
1. Reads the issue body
2. Reads `.github/auto-pr-context.md` from the calling repo for domain-specific instructions
3. Searches the repo for files relevant to the issue
4. Calls Claude (via LiteLLM) to produce a JSON patch with file changes
5. Applies changes and opens a PR

Any repo can use this with a 10-line thin caller that triggers on `issues: labeled` + `startsWith('auto-pr')`.

### `ai-backport-resolver.yml`
Already documented — resolves cherry-pick conflicts from the backport bot.

### Usage example (`auto-pr.yml`)
```yaml
jobs:
  auto-pr:
    if: startsWith(github.event.label.name, 'auto-pr')
    uses: elastic/clients-team-automations/.github/workflows/auto-pr.yml@main
    with:
      issue_number: ${{ github.event.issue.number }}
      search_directory: specification   # optional, defaults to repo root
    secrets:
      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
```

Add `.github/auto-pr-context.md` to your repo with codebase conventions and the workflow handles the rest.