### PR TITLE
fix(ci): remove invalid workflows permission key

### DIFF
--- a/.github/workflows/ai-backport-resolver.yml
+++ b/.github/workflows/ai-backport-resolver.yml
@@ -45,7 +45,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      workflows: write
     steps:
       - name: Check comment is a backport failure
         id: check


### PR DESCRIPTION
## Summary

PR #33 added `workflows: write` to the job permissions but this is not a valid key in the `jobs.<id>.permissions` context — GitHub's workflow parser rejects it with "Unexpected value 'workflows'", breaking the resolver entirely.

Removes the invalid key. The underlying push-to-workflow-files problem is tracked separately; PR #32 handles the generated-files path which covers the case that surfaced it.