### PR TITLE
fix(ci): reset workflow files before push to avoid permission error

### DIFF
--- a/.github/workflows/ai-backport-resolver.yml
+++ b/.github/workflows/ai-backport-resolver.yml
@@ -211,18 +211,27 @@ jobs:
               messages: [{role: "user", content: $prompt}]
             }' > "$payloadfile"
 
-            local response
-            response=$(curl -sf \
+            local response http_status
+            local responsefile="/tmp/llm-response-${filepath//\//-}.json"
+            http_status=$(curl -s -o "$responsefile" -w "%{http_code}" \
               -H "Authorization: Bearer ${LITELLM_API_KEY}" \
               -H "Content-Type: application/json" \
               "https://elastic.litellm-prod.ai/v1/chat/completions" \
               --data-binary @"$payloadfile")
+            response=$(cat "$responsefile")
+
+            if [ "$http_status" -ne 200 ]; then
+              echo "  ERROR: LiteLLM returned HTTP ${http_status} for ${filepath}:"
+              echo "  $(echo "$response" | jq -r '.error.message // .message // .' 2>/dev/null || cat "$responsefile")"
+              return 1
+            fi
 
             local resolved
             resolved=$(echo "$response" | jq -r '.choices[0].message.content // empty')
 
             if [ -z "$resolved" ]; then
-              echo "  ERROR: Empty response from Claude for ${filepath}"
+              echo "  ERROR: Empty content in LiteLLM response for ${filepath}:"
+              echo "  $response"
               return 1
             fi
             if echo "$resolved" | grep -qE '^(<<<<<<<|=======|>>>>>>>)'; then

--- a/.github/workflows/ai-backport-resolver.yml
+++ b/.github/workflows/ai-backport-resolver.yml
@@ -290,6 +290,28 @@ jobs:
 
           GIT_EDITOR=true git cherry-pick --continue
 
+      - name: Reset workflow files to base branch
+        if: steps.check.outputs.should_resolve == 'true'
+        id: reset-workflows
+        env:
+          BASE_BRANCH: ${{ steps.cherry-pick.outputs.base_branch }}
+        run: |
+          set -euo pipefail
+          # GITHUB_TOKEN cannot push changes to .github/workflows/ files.
+          # Reset them to the base branch state so the push succeeds, and
+          # record which files were skipped for the PR description.
+          SKIPPED=$(git diff "$BASE_BRANCH" HEAD -- '.github/workflows/' --name-only 2>/dev/null || true)
+          if [ -n "$SKIPPED" ]; then
+            git checkout "$BASE_BRANCH" -- '.github/workflows/'
+            git add .github/workflows/
+            git commit --amend --no-edit
+            echo "Skipped workflow files (apply manually after merge):"
+            echo "$SKIPPED"
+          fi
+          echo "skipped_workflows<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$SKIPPED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Push backport branch and create PR
         if: steps.check.outputs.should_resolve == 'true'
         env:
@@ -301,6 +323,7 @@ jobs:
           CONFLICTS: ${{ steps.cherry-pick.outputs.conflicts }}
           RESOLVED_LIST: ${{ steps.resolve.outputs.resolved_list }}
           FAILED_FILES: ${{ steps.resolve.outputs.failed_files }}
+          SKIPPED_WORKFLOWS: ${{ steps.reset-workflows.outputs.skipped_workflows }}
         run: |
           set -euo pipefail
 
@@ -308,7 +331,7 @@ jobs:
 
           FULL_TITLE="[${BASE_BRANCH}] ${PR_TITLE}"
 
-          if [ "$CONFLICTS" == "false" ]; then
+          if [ "$CONFLICTS" == "false" ] && [ -z "${SKIPPED_WORKFLOWS:-}" ]; then
             PR_BODY="Backport #${PR_NUMBER} to \`${BASE_BRANCH}\` (no conflicts)."
           else
             printf '%s\n' \
@@ -327,6 +350,16 @@ jobs:
             else
               printf '%s\n' \
                 "> **Please review the AI-resolved conflicts carefully before merging.**" \
+                >> /tmp/pr-body.txt
+            fi
+            if [ -n "${SKIPPED_WORKFLOWS:-}" ]; then
+              printf '%s\n' \
+                "" \
+                "### Skipped workflow files" \
+                "" \
+                "The following files under \`.github/workflows/\` were reset to the base branch state because \`GITHUB_TOKEN\` cannot push workflow file changes. Apply them manually after merging:" \
+                "" \
+                "${SKIPPED_WORKFLOWS}" \
                 >> /tmp/pr-body.txt
             fi
             PR_BODY=$(cat /tmp/pr-body.txt)


### PR DESCRIPTION
## Summary

`GITHUB_TOKEN` cannot push changes to `.github/workflows/` files. When a backport cherry-pick includes changes to workflow files (even cleanly, without conflicts), the push is rejected:

```
refusing to allow a GitHub App to create or update workflow without `workflows` permission
```

This is a hard GitHub restriction - `workflows: write` is not a valid job-level permission in reusable workflows (as confirmed by #33/#34).

## Fix

Add a step before the push that detects any `.github/workflows/` changes in the cherry-picked commit and resets them to the base branch state. The skipped files are listed in the backport PR description so they can be applied manually.

## Test plan

- [ ] Trigger a backport on a PR that touches `.github/workflows/` files and confirm the push succeeds with a note in the PR description about skipped workflow files.

Reproducer: elastic/elasticsearch-specification#6355 backport to `9.3`/`9.4`.